### PR TITLE
chore: bump runtime from node20 to node24

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -99,5 +99,5 @@ outputs:
     description: 'The endpoint URL of the service (from the Application Load Balancer)'
 
 runs:
-  using: 'node20'
+  using: 'node24'
   main: 'dist/index.js'


### PR DESCRIPTION
## Summary

Bumps the action's JavaScript runtime from `node20` to `node24`.

## Why

GitHub Actions is [deprecating Node.js 20](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/) on its runners:

- From **June 2nd 2026**, JavaScript actions are forced to Node.js 24 by default.
- Node.js 20 is **removed from the runner on September 16th 2026**.
- Consumers of this action currently see a deprecation warning on every run:

  > Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: aws-actions/amazon-ecs-deploy-express-service@v1.

Node.js 24 (Krypton) is the current Active LTS, so bumping now aligns the action with both the GitHub Actions default and the upstream Node release schedule.

## Changes

- `action.yml`: `runs.using: 'node20'` → `runs.using: 'node24'`.
- `dist/index.js`: rebuilt via `npm run package` (byte-identical output — no diff committed).

## Test plan

- [x] `npm ci`
- [x] `npm test` — 36/36 passing
- [x] `npm run package` — `dist/` unchanged
- [ ] CI on this PR (`Package` job verifies `dist/index.js` parity, `Check` job runs unit tests)


Made with [Cursor](https://cursor.com)